### PR TITLE
Add history scrollback for input and command modes

### DIFF
--- a/src/xradar/radar.clj
+++ b/src/xradar/radar.clj
@@ -240,7 +240,9 @@
          (satisfies? XScene scene)]}
   (let [profile (fill-profile raw-profile)
         state (atom (deep-merge
-                      {:profile profile
+                      {:history-command (atom [])
+                       :history-insert (atom [])
+                       :profile profile
                        :network network
                        :output-scroll 0
                        :scene scene


### PR DESCRIPTION
Closes #18

Any caller of start-input can provide history, but they must
manage it themselves (for now, at least)
