### PR TITLE
Support VRC-formatted text aliases in native input

### DIFF
--- a/src/xradar/alias.clj
+++ b/src/xradar/alias.clj
@@ -1,0 +1,143 @@
+(ns ^{:author "Daniel Leong"
+      :doc "Text aliases for insert mode"}
+  xradar.alias)
+
+;; pre-declare some funs used recursively
+(declare parse-alias-part)
+(declare expand-part)
+
+;;
+;; Utils
+;;
+
+(defn- cursor-out
+  [cursor-idx part]
+  (let [start (:start part)
+        end (+ start (count (:part part)))]
+    (or (< cursor-idx start)
+        (>= cursor-idx end))))
+
+
+(defn- find-non-whitespace
+  [text start-idx]
+  (if (and
+        (< start-idx (count text))
+        (Character/isWhitespace (.charAt text start-idx)))
+    (recur text (inc start-idx))
+    start-idx))
+
+(defn split-parts
+  "Construct a lazy sequence of space-delimited parts
+  in a sequence, annotated with their start index.
+  Excess spaces are respected but not included as parts"
+  ([text]
+   (lazy-seq (split-parts 0 text)))
+  ([start-idx text]
+   (if (>= start-idx (count text))
+     []
+     (let [next-space (.indexOf text " " start-idx)
+           word-end (if (= -1 next-space)
+                      (count text)
+                      next-space)
+           next-word (.substring text start-idx word-end)
+           next-start (find-non-whitespace
+                        text
+                        (+ start-idx (count next-word) 1))]
+       (if (empty? next-word)
+         []
+         (cons {:part next-word
+                :start start-idx}
+               (lazy-seq (split-parts next-start text))))))))
+
+;;
+;; Parsing into AST
+;;
+
+(defn parse-variable
+  [part]
+  (if (re-matches #"\$\d+" part)
+    {:type :positional
+     :index (Integer/parseInt (.substring part 1))}
+    {:type :var
+     :name (.substring part 1)}))
+
+(defn parse-function
+  [part]
+  (let [args-start (.indexOf part "(")
+        args (.substring part 
+                         (inc args-start) 
+                         (dec (count part)))]
+    {:type :func
+     :name (.substring part 1 args-start)
+     :args (parse-alias-part args)}))
+
+(defn parse-alias-part
+  [part]
+  (let [special (first part)]
+    (case special
+      \. {:type :nested
+          :value part}
+      \$ (if (.contains part "(")
+           (parse-function part)
+           (parse-variable part))
+      part)))
+
+(defn parse-alias
+  [raw]
+  (let [all-parts (map :part (split-parts raw))
+        aname (first all-parts)
+        parts (->> (rest all-parts)
+                   (map parse-alias-part))]
+    {:alias aname
+     :parts parts}))
+
+;;
+;; Expansion of values
+;;
+
+(defn- expand-function
+  [state info function]
+  (when-let [eval-fun 
+             (get-in @state
+                     [:functions (keyword (:name function))])]
+    (when-let [args (expand-part state info (:args function))]
+      (eval-fun state args))))
+
+(defn expand-part
+  [state info part]
+  (let [parsed (cond
+                 (:type part) part
+                 (:part part) (parse-alias-part (:part part))
+                 :else (parse-alias-part part))]
+    (condp = (:type parsed)
+      nil (or (:part part) part) ;; IE strings are always expanded
+      :positional nil
+      :var (when-let [var-fun 
+                      (get-in @state 
+                              [:variables (keyword (:name parsed))])]
+             (var-fun state))
+      :func (when (or
+                    (nil? (:start part))
+                    (cursor-out (:cursor info) part))
+              (expand-function state info parsed))
+      :else nil)))
+
+(defn expand-values
+  "Expand aliases, functions, and variables
+  in text, if possible. `info` is a map
+  of info relevant to this expansion, and must
+  include the cursor position--for example,
+  `$foo($1)` cannot be evaluated if the cursor
+  is still inside the parenthesis, since the
+  user might still be providing it."
+  [state info text]
+  {:pre [(contains? info :cursor)]}
+  (let [buf (StringBuilder. text)]
+    (doseq [part (split-parts text)]
+      (when-let [expanded (expand-part state info part)]
+        ;; don't bother unless it's different
+        (when (not= expanded (:part part))
+          (let [start (:start part)
+                end (+ start (count (:part part)))]
+            (.replace buf start end expanded)))))
+    (str buf)))

--- a/src/xradar/alias.clj
+++ b/src/xradar/alias.clj
@@ -148,13 +148,14 @@
 
 (defn parse-alias
   [raw]
-  (let [all-parts (map :part (split-parts raw))
-        aname (first all-parts)
-        parts (->> (rest all-parts)
-                   (map parse-alias-part))]
-    {:alias aname
-     :parts parts
-     :body (subs raw (inc (count aname)))}))
+  (when (= \. (first raw))
+    (let [all-parts (map :part (split-parts raw))
+         aname (first all-parts)
+         parts (->> (rest all-parts)
+                    (map parse-alias-part))]
+     {:alias aname
+      :parts parts
+      :body (subs raw (inc (count aname)))})))
 
 ;;
 ;; Expansion of values

--- a/src/xradar/alias_vars.clj
+++ b/src/xradar/alias_vars.clj
@@ -1,0 +1,31 @@
+(ns ^{:author "Daniel Leong"
+      :doc "Variables and functions for use in aliases"}
+  xradar.alias-vars
+  (:require [clojure.string :refer [lower-case upper-case]]
+            [clj-time.format :as f]
+            [xradar.network :refer [my-callsign]]))
+
+(defn- aircraft-var
+  [var-name]
+  (fn [state]
+    (when-let [selected (:selected @state)]
+      (get-in @state [:aircraft selected var-name]))))
+
+(def alias-variables
+  {:squawk (aircraft-var :squawk)
+   :route (aircraft-var :route)
+   :arr (aircraft-var :arrive)
+   :dep (aircraft-var :depart)
+   :cruise (aircraft-var :cruise)
+   :calt (aircraft-var :altitude)
+   :aircraft (aircraft-var :callsign)
+   :callsign (fn [state]
+               (my-callsign (:network @state)))
+   ;; TODO there are still plenty of vars we could support
+   })
+
+(def alias-functions
+  {:lc #(lower-case %2)
+   :uc #(upper-case %2)
+   ;; TODO many functions
+   })

--- a/src/xradar/bindings.clj
+++ b/src/xradar/bindings.clj
@@ -6,6 +6,7 @@
              [string :refer [split]]]
             [clojure.java.io :as io]
             [xradar
+             [alias :refer [parse-alias]]
              [util :refer [deep-merge]]]))
 
 (def default-bindings-filename "default-bindings.edn")
@@ -36,6 +37,9 @@
     (case command
       "map" {:bindings (read-map parts value)}
       "set" {:settings (read-set parts value)}
+      "alias" (if-let [the-alias (parse-alias value)]
+                {:aliases {(:alias the-alias) the-alias}}
+                (println "Unable to parse alias" value))
       (println "Unsupported command" command))))
 
 (defn read-bindings

--- a/src/xradar/commands.clj
+++ b/src/xradar/commands.clj
@@ -160,6 +160,7 @@
     (assoc moded
            :insert-box 
            (create-insert 
+             state
              x 
              (+ y (q/height) (- input-height)) 
              (q/width)

--- a/src/xradar/native_insert.clj
+++ b/src/xradar/native_insert.clj
@@ -64,18 +64,22 @@
                            (key-handler on-submit on-cancel %)
                            (catch Exception e
                              (def last-exc e)))
-           :key-released #(let [input (s/to-widget %)
-                                expanded (expand-values 
-                                           state
-                                           {:cursor (-> input
-                                                        (.getCaret)
-                                                        (.getDot))}
-                                           (s/value input))]
-                            (def cursor (-> input
-                                            (.getCaret)
-                                            (.getDot)))
-                            (def last-expanded expanded)
-                            (def last-value (s/value input)))])
+           :key-released #(try
+                            (let [input (s/to-widget %)
+                                  expanded (expand-values 
+                                             state
+                                             {:cursor (-> input
+                                                          (.getCaret)
+                                                          (.getDot))}
+                                             (s/value input))]
+                              (def cursor (-> input
+                                              (.getCaret)
+                                              (.getDot)))
+                              (def last-expanded expanded)
+                              (def last-value (s/value input))
+                              (s/value! input expanded))
+                            (catch Exception e
+                              (def last-exc e)))])
         contents
         (if (string? prompt)
           (mig-panel

--- a/src/xradar/native_insert.clj
+++ b/src/xradar/native_insert.clj
@@ -5,49 +5,16 @@
             [seesaw
              [core :as s]
              [mig :refer [mig-panel]]]
-            [xradar.alias :refer [expand-values]]))
+            [xradar.alias :refer [expand-values]])
+  (:import [java.awt.event InputEvent]))
 
 (def input-height 30)
 
-(defn- key-handler
-  [on-submit on-cancel key-event]
-  (def last-event key-event)
-  (def last-event-code (.getKeyCode key-event))
-  (let [root (s/to-root key-event)
-        input (s/select root [:#input])
-        {:keys [scrollback history]} 
-         (s/user-data input)]
-    (case (.getKeyCode key-event)
-      ;; enter; submit the text
-      10 (let [content (.trim (s/value (s/to-widget key-event)))]
-           (-> root
-               s/dispose!)
-           (if (empty? content)
-             (on-cancel)
-             (on-submit content)))
-      ;; esc; dispose the window
-      27 (do
-           (-> root
-               s/dispose!)
-           (on-cancel))
-      ;; up-arrow; history scroll-back
-      38 (when (and
-                 (seq history)
-                 (< (inc @scrollback) (count history)))
-           (let [new-idx (swap! scrollback inc)]
-             (s/value! input (nth history new-idx))))
-      ;; down-arrow; history scroll-forward
-      40 (when (and
-                 (seq history)
-                 (>= @scrollback 0))
-           (let [new-idx (swap! scrollback dec)]
-             (def last-idx new-idx)
-             (s/value! input 
-                       (if (< new-idx 0)
-                         ""
-                         (nth history new-idx)))))
-      ;; anything else, do nothing
-      false)))
+(defn- get-cursor
+  [input]
+  (-> input
+      (.getCaret)
+      (.getDot)))
 
 (defn select-next-var
   [text & {:keys [from dir] :or {from 0 dir :right}}]
@@ -83,15 +50,67 @@
           ;; otherwise, keep looking backwards
           :else (select-next-var text :from previous-dollar :dir dir))))))
 
+
+(defn- key-handler
+  [on-submit on-cancel key-event]
+  (def last-event key-event)
+  (def last-event-code (.getKeyCode key-event))
+  (let [root (s/to-root key-event)
+        input (s/select root [:#input])
+        {:keys [scrollback history]} 
+         (s/user-data input)]
+    (case (.getKeyCode key-event)
+      ;; tab; try to hop between numbered vars
+      9 (let [mods (.getModifiers key-event)
+              dir (if (= InputEvent/SHIFT_MASK mods)
+                    :left
+                    :right)
+              sel-func (if (= :left dir) first second)
+              selection (s/selection input)
+              cursor (or (sel-func selection) (get-cursor input))]
+          (when-let [next-var (select-next-var
+                                (s/value input) 
+                                :from cursor
+                                :dir dir)]
+            (s/selection! input next-var)))
+      ;; enter; submit the text
+      10 (let [content (.trim (s/value input))]
+           (-> root
+               s/dispose!)
+           (if (empty? content)
+             (on-cancel)
+             (on-submit content)))
+      ;; esc; dispose the window
+      27 (do
+           (-> root
+               s/dispose!)
+           (on-cancel))
+      ;; up-arrow; history scroll-back
+      38 (when (and
+                 (seq history)
+                 (< (inc @scrollback) (count history)))
+           (let [new-idx (swap! scrollback inc)]
+             (s/value! input (nth history new-idx))))
+      ;; down-arrow; history scroll-forward
+      40 (when (and
+                 (seq history)
+                 (>= @scrollback 0))
+           (let [new-idx (swap! scrollback dec)]
+             (def last-idx new-idx)
+             (s/value! input 
+                       (if (< new-idx 0)
+                         ""
+                         (nth history new-idx)))))
+      ;; anything else, do nothing
+      false)))
+
 (defn- alias-expander
   [state key-event]
   (let [input (s/to-widget key-event)
         old-value (s/value input)
         expanded (expand-values 
                    state
-                   {:cursor (-> input
-                                (.getCaret)
-                                (.getDot))}
+                   {:cursor (get-cursor input)}
                    old-value)]
     (when (not= old-value expanded)
       (s/value! input expanded)
@@ -104,19 +123,21 @@
   [state x y w & {:keys [prompt history on-submit on-cancel]}]
   {:pre [(function? on-submit) (function? on-cancel)]}
   (let [input 
-        (s/text 
-          :id :input
-          :user-data {:scrollback (atom -1)
-                      :history history}
-          :listen 
-          [:key-pressed #(try
-                           (key-handler on-submit on-cancel %)
-                           (catch Exception e
-                             (def last-exc e)))
-           :key-released #(try
-                            (alias-expander state %)
-                            (catch Exception e
-                              (def last-exc e)))])
+        (doto
+          (s/text 
+            :id :input
+            :user-data {:scrollback (atom -1)
+                        :history history}
+            :listen 
+            [:key-pressed #(try
+                             (key-handler on-submit on-cancel %)
+                             (catch Exception e
+                               (def last-exc e)))
+             :key-released #(try
+                              (alias-expander state %)
+                              (catch Exception e
+                                (def last-exc e)))])
+          (.setFocusTraversalKeysEnabled false))
         contents
         (if (string? prompt)
           (mig-panel

--- a/src/xradar/profile.clj
+++ b/src/xradar/profile.clj
@@ -33,7 +33,8 @@
     (read-bindings (reader input))
     (catch java.io.FileNotFoundException e
       ;; not there? just be empty
-      {:settings {}
+      {:aliases {}
+       :settings {}
        :bindings {}})))
 
 (defn read-profile
@@ -55,7 +56,8 @@
        deep-merge 
        [(:settings settings)
         (:settings profile)
-        {:bindings (:bindings profile)}]))))
+        {:aliases (:aliases profile)}
+        {:bindings (:bindings profile {})}]))))
 
 (defn- pick-settings-file
   [radar]

--- a/src/xradar/radar.clj
+++ b/src/xradar/radar.clj
@@ -6,6 +6,7 @@
              [core :as q] 
              [middleware :as qm]]
             [xradar
+             [alias-vars :refer [alias-functions alias-variables]]
              [input :refer [create-input describe-input 
                             process-input-press process-input-release
                             reset-modifiers!]]
@@ -221,13 +222,15 @@
          (satisfies? XScene scene)]}
   (let [profile (fill-profile raw-profile)
         state (atom (deep-merge
-                      {:history-command (atom [])
+                      {:functions alias-functions
+                       :history-command (atom [])
                        :history-insert (atom [])
                        :profile profile
                        :network network
                        :output-scroll 0
                        :scene scene
                        :strips (create-strip-bay)
+                       :variables alias-variables
                        :aircraft {}}
                       (create-output-buffers)))]
     (q/defsketch xradar

--- a/test/xradar/alias_test.clj
+++ b/test/xradar/alias_test.clj
@@ -1,0 +1,143 @@
+(ns xradar.alias-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :refer [upper-case]]
+            [xradar.alias :refer :all]))
+
+(deftest split-parts-test
+  (testing "Empty string"
+    (is (= [] (split-parts ""))))
+  (testing "Single word"
+    (is (= [{:part "Now" :start 0}] (split-parts "Now"))))
+  (testing "Two words"
+    (is (= [{:part "Now" :start 0}
+            {:part "I've" :start 4}] 
+           (split-parts "Now I've"))))
+  (testing "Multi-word"
+    (is (= [{:part "Now" :start 0}
+            {:part "I've" :start 4}
+            {:part "found" :start 9}
+            {:part "Serenity" :start 15}]
+           (split-parts "Now I've found Serenity"))))
+  (testing "Excess Spaces"
+    (is (= [{:part "Keep" :start 0}
+            {:part "Flyin'" :start 7}]
+           (split-parts "Keep   Flyin'")))))
+
+(deftest split-parts-lazily
+  (testing "Lazy eval with StringBuilder"
+    (let [buf (StringBuilder. "a b c d")
+          parts (split-parts buf)]
+      (is (= {:part "a" :start 0} (first parts)))
+      (let [rest1 (rest parts)]
+        (.replace buf 2 3 "bar")
+        (is (= {:part "bar" :start 2} (second parts)))
+        (is (= {:part "bar" :start 2} (first rest1)))
+        (let [rest2 (rest rest1)]
+          (.replace buf 6 7 "cat")
+          (is (= {:part "cat" :start 6} (nth parts 2)))
+          (is (= {:part "cat" :start 6} (first rest2)))))))
+  (testing "Lazy eval in doseq"
+    (let [buf (StringBuilder. "a b")
+          parts (atom [])]
+      (doseq [part (split-parts buf)]
+        (swap! parts conj part)
+        (when (= 1 (count @parts))
+          (.replace buf 2 3 "bar")))
+      (is (= [{:part "a" :start 0}
+              {:part "bar" :start 2}]
+             @parts)))))
+
+(deftest parse-alias-test
+  (testing "Simple"
+    (is (= {:alias ".hi"
+            :parts ["hello" "there"]}
+           (parse-alias ".hi hello there"))))
+  (testing "Positional Variable"
+    (is (= {:alias ".hi"
+            :parts ["hello," {:type :positional
+                              :index 1}]}
+           (parse-alias ".hi hello, $1"))))
+  (testing "Variable"
+    (is (= {:alias ".hi"
+            :parts ["hello," {:type :var
+                              :name "callsign"}]}
+           (parse-alias ".hi hello, $callsign"))))
+  (testing "Function"
+    (is (= {:alias ".hi"
+            :parts ["hello," {:type :func
+                              :name "foo"
+                              :args "1"}]}
+           (parse-alias ".hi hello, $foo(1)"))))
+  (testing "Function with variable"
+    (is (= {:alias ".hi"
+            :parts ["hello," {:type :func
+                              :name "foo"
+                              :args {:type :positional
+                                     :index 1}}]}
+           (parse-alias ".hi hello, $foo($1)"))))
+  (testing "Nested Function with variable"
+    (is (= {:alias ".hi"
+            :parts ["hello," {:type :func
+                              :name "foo"
+                              :args {:type :func
+                                     :name "uc"
+                                     :args {:type :positional
+                                            :index 1}}}]}
+           (parse-alias ".hi hello, $foo($uc($1))")))))
+
+(defmacro expand
+  [text]
+  `(expand-values ~'state ~'info ~text))
+
+(deftest expand-test
+  (testing "Just text"
+    (let [state (atom {})
+          info {:cursor 5}]
+      (is (= "Hello" (expand "Hello")))
+      (is (= "Hello World" (expand "Hello World")))))
+  (testing "Expand variables"
+    (let [state (atom {:variables
+                       {:keep (constantly "Flyin'")
+                        :who (constantly "I've")
+                        :what (constantly "Serenity")}})
+          info {:cursor 5}]
+      ;; positional variables cannot be expanded
+      (is (= "Keep $1" (expand "Keep $1")))
+      ;; regular ones can, though
+      (is (= "Keep Flyin'" (expand "Keep $keep")))
+      (is (= "Now I've found Serenity" (expand "Now $who found $what")))))
+  (testing "Expand functions"
+    (let [state (atom {:variables
+                       {:keep (constantly "Flyin'")
+                        :who (constantly "I've")
+                        :what (constantly "Serenity")}
+                       :functions
+                       {:uc #(upper-case %2)}})
+          info {:cursor 4}]
+      ;; positional variables cannot be expanded,
+      ;;  so neither can the function
+      (is (= "Just $uc($1)" (expand "Just $uc($1)")))
+      ;; regular ones can, though
+      (is (= "Keep FLYIN'" (expand "Keep $uc($keep)")))))
+  (testing "Don't expand functions when cursor is inside"
+    (let [state (atom {:functions
+                       {:uc #(upper-case %2)}}) ]
+      (let [info {:cursor 13}]
+        ;; cursor just within
+        (is (= "Just $uc(doit)" (expand "Just $uc(doit)"))))
+      (let [info {:cursor 14}]
+        ;; cursor just without
+        (is (= "Just DOIT" (expand "Just $uc(doit)"))))))
+  (testing "Nested functions"
+    (let [state (atom {:variables
+                       {:keep (constantly "Flyin'")
+                        :who (constantly "I've")
+                        :what (constantly "Serenity")}
+                       :functions
+                       {:uc #(upper-case %2)
+                        :freakin #(str "Freakin' " %2)}})
+          info {:cursor 4}]
+      ;; as usual, an unresolved positional can stop the signal
+      (is (= "Keep $freakin($uc($1))" (expand "Keep $freakin($uc($1))")))
+      (is (= "Keep Freakin' FLYIN'" (expand "Keep $freakin($uc($keep))")))
+      (is (= "Keep FREAKIN' FLYIN'" (expand "Keep $uc($freakin($keep))"))))))

--- a/test/xradar/bindings_test.clj
+++ b/test/xradar/bindings_test.clj
@@ -33,7 +33,9 @@
       (is (= {:normal {:g {:up {:call 'start-insert}}}} result))))
   (testing "Settings"
     (let [result (settings "#set/timeout-len 500")]
-      (is (= {:timeout-len 500} result))))
+      (is (= {:timeout-len 500} result)))
+    (let [result (settings "#set/alias-file \"~/Foo.txt\"")]
+      (is (= {:alias-file "~/Foo.txt"} result))))
   (testing "Aliases"
     (let [result (aliases "#alias \".afv Cleared as filed\"")]
       (is (= {".afv" {:alias ".afv"

--- a/test/xradar/bindings_test.clj
+++ b/test/xradar/bindings_test.clj
@@ -37,5 +37,6 @@
   (testing "Aliases"
     (let [result (aliases "#alias \".afv Cleared as filed\"")]
       (is (= {".afv" {:alias ".afv"
+                      :body "Cleared as filed"
                       :parts ["Cleared" "as" "filed"]}}
              result)))))

--- a/test/xradar/bindings_test.clj
+++ b/test/xradar/bindings_test.clj
@@ -3,6 +3,10 @@
             [xradar
              [bindings :refer :all]]))
 
+(defn aliases
+  [string]
+  (:aliases (read-str-bindings string)))
+
 (defn bindings
   [string]
   (:bindings (read-str-bindings string)))
@@ -13,20 +17,25 @@
 
 (deftest read-bindings-test
   (testing "Single key mode map"
-    (let [bindings (bindings "#map/normal/i start-insert")]
-      (is (= {:normal {:i {:call 'start-insert}}} bindings))))
+    (let [result (bindings "#map/normal/i start-insert")]
+      (is (= {:normal {:i {:call 'start-insert}}} result))))
   (testing "Single special key mode map"
-    (let [bindings (bindings "#map/insert/<esc> stop-insert")]
-      (is (= {:insert {:esc {:call 'stop-insert}}} bindings))))
+    (let [result (bindings "#map/insert/<esc> stop-insert")]
+      (is (= {:insert {:esc {:call 'stop-insert}}} result))))
   (testing "Key with modifier"
-    (let [bindings (bindings "#map/normal/<ctrl-f> stop-insert")]
-      (is (= {:normal {:ctrl-f {:call 'stop-insert}}} bindings))))
+    (let [result (bindings "#map/normal/<ctrl-f> stop-insert")]
+      (is (= {:normal {:ctrl-f {:call 'stop-insert}}} result))))
   (testing "Multi-key mode map"
-    (let [bindings (bindings "#map/normal/gi start-insert")]
-      (is (= {:normal {:g {:i {:call 'start-insert}}}} bindings))))
+    (let [result (bindings "#map/normal/gi start-insert")]
+      (is (= {:normal {:g {:i {:call 'start-insert}}}} result))))
   (testing "Multi-key mode map with a special key"
-    (let [bindings (bindings "#map/normal/g<up> start-insert")]
-      (is (= {:normal {:g {:up {:call 'start-insert}}}} bindings))))
+    (let [result (bindings "#map/normal/g<up> start-insert")]
+      (is (= {:normal {:g {:up {:call 'start-insert}}}} result))))
   (testing "Settings"
-    (let [bindings (settings "#set/timeout-len 500")]
-      (is (= {:timeout-len 500} bindings)))))
+    (let [result (settings "#set/timeout-len 500")]
+      (is (= {:timeout-len 500} result))))
+  (testing "Aliases"
+    (let [result (aliases "#alias \".afv Cleared as filed\"")]
+      (is (= {".afv" {:alias ".afv"
+                      :parts ["Cleared" "as" "filed"]}}
+             result)))))

--- a/test/xradar/native_insert_test.clj
+++ b/test/xradar/native_insert_test.clj
@@ -3,9 +3,27 @@
             [xradar.native-insert :refer :all]))
 
 (deftest select-next-var-test
+  (testing "Nothing at all"
+    (is (= nil (select-next-var "well, hello")))
+    (is (= nil (select-next-var "well, hello" 
+                                :dir :left :from 2))))
   (testing "Find the first one"
     (is (= [0 2] (select-next-var "$1, hello")))
     (is (= [7 9] (select-next-var "hello, $1"))))
   (testing "Find the next one"
     (is (= [8 10] (select-next-var "$1, via $2" :from 2)))
-    (is (= [8 10] (select-next-var "hi, via $2" :from 2)))))
+    (is (= [8 10] (select-next-var "hi, via $2" :from 2))))
+  (testing "Loop around for next one"
+    (is (= [0 2] (select-next-var "$1, via $2" :from 9))))
+  (testing "Find the previous one"
+    (is (= [0 2] (select-next-var "$1, via $2" 
+                                   :from 8 :dir :left)))
+    (is (= [8 10] (select-next-var "hi, via $2"
+                                   :from 10 :dir :left))))
+  (testing "Loop around for previous one"
+    (is (= [8 10] (select-next-var "$1, via $2" 
+                                   :from 0 :dir :left))))
+  (testing "Don't be confused"
+    (is (= [12 14] (select-next-var "$1, $foo at $2" :from 2)))
+    (is (= [0 2] (select-next-var "$1, $foo at $2" 
+                                  :from 11 :dir :left)))))

--- a/test/xradar/native_insert_test.clj
+++ b/test/xradar/native_insert_test.clj
@@ -1,0 +1,11 @@
+(ns xradar.native-insert-test
+  (:require [clojure.test :refer :all]
+            [xradar.native-insert :refer :all]))
+
+(deftest select-next-var-test
+  (testing "Find the first one"
+    (is (= [0 2] (select-next-var "$1, hello")))
+    (is (= [7 9] (select-next-var "hello, $1"))))
+  (testing "Find the next one"
+    (is (= [8 10] (select-next-var "$1, via $2" :from 2)))
+    (is (= [8 10] (select-next-var "hi, via $2" :from 2)))))


### PR DESCRIPTION
Still some vars and functions that are unsupported, as mentioned in 30984d6, but most of the basics are in.
